### PR TITLE
Mise à jours de discord.js (13.5.0 -> 13.8.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ misc/
 
 config.json
 deploy-commands.js
+
+#IDE files
+.idea
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@discordjs/builders": "^0.11.0",
         "@discordjs/rest": "^0.2.0-canary.0",
         "discord-api-types": "^0.26.1",
-        "discord.js": "^13.5.0",
+        "discord.js": "^13.8.0",
         "moment": "^2.29.1",
         "mongoose": "^6.1.6",
         "node-forge": "^1.2.1"
       },
       "engines": {
-        "node": "16.x"
+        "node": "16.8.0"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -72,9 +72,18 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
+      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.3.0.tgz",
+      "integrity": "sha512-6MNupTaIXtyVCHuejbTIE/Wmw35FKbpfRhiPCkxaQHm76iHICaWNO0oej0lipLb7vhK8mQHQn3zE6umOVvwGLw==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -90,9 +99,9 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.3.0.tgz",
-      "integrity": "sha512-wwOvh0eO3PiTEivGJWiZ+b946SlMSb4pe+y+Ur/4S87cwo09pYi+FWHHnbrM3W9W7cBYKDqQXcrFYjYUCOJUEQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "engines": {
         "node": ">=10"
       },
@@ -106,9 +115,9 @@
       "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -142,9 +151,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -259,33 +268,58 @@
       }
     },
     "node_modules/discord.js": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.6.0.tgz",
-      "integrity": "sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.8.0.tgz",
+      "integrity": "sha512-EPAA/2VLycYN5wSzavqa4iJ6qj3UtQFtHw5TH/60Fj29ymfEsCQVn//o1mTpwDxzwb+rPIrWhkxKIGGnjfv0Iw==",
       "dependencies": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.14.0",
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.33.3",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "ws": "^8.7.0"
       },
       "engines": {
         "node": ">=16.6.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/discord.js/node_modules/@discordjs/collection": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-      "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==",
+    "node_modules/discord.js/node_modules/@discordjs/builders": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+      "dependencies": {
+        "@sapphire/shapeshift": "^3.1.0",
+        "@sindresorhus/is": "^4.6.0",
+        "discord-api-types": "^0.33.3",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.4.0"
+      },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
       }
+    },
+    "node_modules/discord.js/node_modules/@discordjs/collection": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/discord.js/node_modules/discord-api-types": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -539,14 +573,14 @@
       }
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
+      "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -569,9 +603,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -637,9 +671,14 @@
       }
     },
     "@sapphire/async-queue": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
+      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g=="
+    },
+    "@sapphire/shapeshift": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.3.0.tgz",
+      "integrity": "sha512-6MNupTaIXtyVCHuejbTIE/Wmw35FKbpfRhiPCkxaQHm76iHICaWNO0oej0lipLb7vhK8mQHQn3zE6umOVvwGLw=="
     },
     "@sapphire/snowflake": {
       "version": "3.0.1",
@@ -647,9 +686,9 @@
       "integrity": "sha512-v+wCC2q9DK3OhG7Vcdt/8A/INAYiyhlMD5snakmXGBN1usLBwSGJVJBjDHv4VGI5C9YYl4UdW5Ovr3arvYsJXQ=="
     },
     "@sindresorhus/is": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.3.0.tgz",
-      "integrity": "sha512-wwOvh0eO3PiTEivGJWiZ+b946SlMSb4pe+y+Ur/4S87cwo09pYi+FWHHnbrM3W9W7cBYKDqQXcrFYjYUCOJUEQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@types/node": {
       "version": "17.0.10",
@@ -657,9 +696,9 @@
       "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -692,9 +731,9 @@
       }
     },
     "@types/ws": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "requires": {
         "@types/node": "*"
       }
@@ -758,27 +797,50 @@
       "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ=="
     },
     "discord.js": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.6.0.tgz",
-      "integrity": "sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.8.0.tgz",
+      "integrity": "sha512-EPAA/2VLycYN5wSzavqa4iJ6qj3UtQFtHw5TH/60Fj29ymfEsCQVn//o1mTpwDxzwb+rPIrWhkxKIGGnjfv0Iw==",
       "requires": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.14.0",
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.33.3",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "ws": "^8.7.0"
       },
       "dependencies": {
+        "@discordjs/builders": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+          "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+          "requires": {
+            "@sapphire/shapeshift": "^3.1.0",
+            "@sindresorhus/is": "^4.6.0",
+            "discord-api-types": "^0.33.3",
+            "fast-deep-equal": "^3.1.3",
+            "ts-mixer": "^6.0.1",
+            "tslib": "^2.4.0"
+          }
+        },
         "@discordjs/collection": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-          "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw=="
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+          "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
+        },
+        "discord-api-types": {
+          "version": "0.33.5",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+          "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
         }
       }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -969,14 +1031,14 @@
       }
     },
     "ts-mixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
+      "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "webidl-conversions": {
       "version": "7.0.0",
@@ -993,9 +1055,9 @@
       }
     },
     "ws": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "requires": {}
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@discordjs/builders": "^0.11.0",
     "@discordjs/rest": "^0.2.0-canary.0",
     "discord-api-types": "^0.26.1",
-    "discord.js": "^13.5.0",
+    "discord.js": "^13.8.0",
     "moment": "^2.29.1",
     "mongoose": "^6.1.6",
     "node-forge": "^1.2.1"


### PR DESCRIPTION
Cette PR met à jour discord.js vers la version 13.8.0 

Elle rajoute aussi le fait d'ignorer les dossiers spécifiques à VSC et aux IDEs de l'entreprise Jetbrains. Cela peut si besoin être mis dans une autre PR